### PR TITLE
Adding execute permission onto /app/entrypoint.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,5 +19,6 @@ ENV MINIO_API_VERSION="S3v4"
 ENV DATE_FORMAT="+%Y-%m-%d"
 
 ADD entrypoint.sh /app/entrypoint.sh
+RUN chmod +x /app/entrypoint.sh
 
 ENTRYPOINT [ "/app/entrypoint.sh" ]


### PR DESCRIPTION
when editing the `entrypoint.sh` file from windows 10 permission to execute is not persisted, so we had to add this permission in order to successfully execute pg_dump command